### PR TITLE
Accessibility update and tracking update

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "lodash.get": "^4.4.2",
-    "losen": "^3.2.4",
+    "losen": "^6.0.0",
     "prop-types": "^15.6.2",
     "react": "^15.6.1",
     "react-autobind": "^1.0.6",

--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ import store from './store';
 
 export default class App extends Component {
   static trackIntro() {
-    track(data.meta.name, 'intro', 'Tilbygg - Bod, sykkelbod, vedbod, søppelskur');
+    track(data.meta.name, 'intro', 'Bygg uten å søke - tilbygg');
   }
 
   static propTypes = {
@@ -35,7 +35,7 @@ export default class App extends Component {
   closeIntro() {
     this.setState({ intro: false });
     window.scrollTo(0, 0);
-    trackEvent('close-intro');
+    trackEvent('Close intro');
   }
 
   showIntro() {


### PR DESCRIPTION
Updated losen to version 6.0.0 that includes [accessibility fixes for WCAG 2.1](https://github.com/DirektoratetForByggkvalitet/losen/pull/186) and [replace Google Analytics tracking with Matomo](https://github.com/DirektoratetForByggkvalitet/losen/pull/185).